### PR TITLE
highlight metadata references

### DIFF
--- a/syntaxes/bloblang.tmLanguage.json
+++ b/syntaxes/bloblang.tmLanguage.json
@@ -48,6 +48,10 @@
         {
           "name": "variable.name.reference.bloblang",
           "match": "\\$\\w+\\b"
+        },
+        {
+          "name": "variable.name.meta.bloblang",
+          "match": "@(?:\\w+\\b)?"
         }
       ]
     },


### PR DESCRIPTION
This change highlights metadata references using the new syntax (`@some_key`).