### PR TITLE
enable opt-in syntax highlighting for js code

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
         "path": "./syntaxes/yaml-mappings.tmLanguage.json",
         "scopeName": "mapping.bloblang.injection",
         "embeddedLanguages": {
-          "meta.embedded.inline.bloblang": "bloblang"
+          "meta.embedded.inline.blobl.bloblang": "bloblang",
+          "meta.embedded.block.javascript": "javascript"
         }
       }
     ]

--- a/syntaxes/yaml-mappings.tmLanguage.json
+++ b/syntaxes/yaml-mappings.tmLanguage.json
@@ -12,6 +12,20 @@
       },
       "contentName": "meta.embedded.inline.bloblang",
       "patterns": [{ "include": "source.bloblang" }]
+    },
+    {
+      "comment": "Embedded JavaScript mapping",
+      "begin": "^([ ]+)(?! )(//!js)",
+      "end": "^(?!\\1|\\s*$)",
+      "beginCaptures": {
+        "2": { "name": "punctuation.definition.comment.bloblang" }
+      },
+      "contentName": "meta.embedded.block.javascript",
+      "patterns": [
+        {
+          "include": "source.js"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Opting in is done by adding a `//!js` pragma at the start of a yaml multi-line string. This is needed until a language service is provided for benthos-yaml that can provide a richer experience beyond just syntax highlighting.

<img width="571" alt="image" src="https://user-images.githubusercontent.com/678548/234862430-4c47b607-a64f-4975-8a0f-e70f761df93d.png">
